### PR TITLE
Set up dask usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,16 @@ This is usually done for debugging and testing purposes. The list of sample labe
 * `-N`: number of files from the sample to run over. Default is -1.
 * `-M`: index of the first file to run over.
 * `-w`: number of workers.
-* `-s`: chunksize; an input for the coffea processor. It determines how many events to process at the same time.
+* `-s`: chunksize; an input for the coffea processor. It determines how many events to process at the same time.  
 Sometimes it is helpful to use `-w 1 -s 2` for debugging.
+
+Dask can be used to run `analyze.py` in parallel, either locally or on Condor. The relevant options are:
+* `--dask`: run w/ dask
+* `--port`: port for dask status dashboard
+* `--mincores`: dask waits for min # cores
+* `--quiet`: suppress status printouts  
+To view the status dashboard, specify `--port 8NNN` (using the forwarded port from the earlier ssh command)
+and navigate to `localhost:8NNN` in a web browser.
 
 To make histograms on condor, cd into the `condor` directory and run
 ```bash

--- a/analyze.py
+++ b/analyze.py
@@ -22,7 +22,7 @@ def use_dask(njobs,port):
     hostname = socket.gethostname()
 
     cluster = HTCondorCluster(
-        scheduler_options = {'host': f'{hostname}:10000'},
+        scheduler_options = {'host': f'{hostname}:10000', 'dashboard_address': ':{}'.format(port)},
         cores=1,
         memory="2GB",
         disk="2GB",
@@ -30,7 +30,6 @@ def use_dask(njobs,port):
         nanny=False,
         extra=extra,
         job_extra=job_extra,
-        diagnostics_port=port,
     )
 
     cluster.scale(jobs=njobs)
@@ -61,6 +60,7 @@ def main():
     parser.add_option(      '--condor',    help='running on condor', dest='condor',              default=False, action='store_true')
     parser.add_option(      '--dask',      help='running on condor w/ dask', dest='dask',              default=False, action='store_true')
     parser.add_option(      '--port',      help='port for dask status dashboard (localhost:port)', dest='port', type=int, default=8787)
+    parser.add_option(      '--mincores',  help='dask waits for min # cores', dest='mincores', type=int, default=4)
     parser.add_option(      '--quiet',     help='suppress status printouts', dest='quiet',              default=False, action='store_true')
     parser.add_option('-w', '--workers',   help='Number of workers to use for multi-worker executors (e.g. futures or condor)', dest='workers', type=int, default=8)
     parser.add_option('-s', '--chunksize', help='Chunk size',        dest='chunksize', type=int, default=10000)
@@ -81,7 +81,7 @@ def main():
         if options.quiet: exe_args['status'] = False
 
         client = exe_args['client']
-        while len(client.ncores()) < 4:
+        while len(client.ncores()) < options.mincores:
             print('Waiting for more cores to spin up, currently there are {0} available...'.format(len(client.ncores())))
             print('Dask client info ->', client)
             time.sleep(10)

--- a/analyze.py
+++ b/analyze.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 from coffea import hist, processor
 from processors.mainProcessor import MainProcessor
 import uproot
@@ -15,6 +16,7 @@ def use_dask(condor,njobs,port):
 
     # make list of local package directories (absolute paths) that should be sent to jobs
     initpylist = [os.path.abspath(os.path.dirname(x)) for x in glob('*/__init__.py')]
+    initpylist.append("patch.sh")
     job_extra = {'transfer_input_files': ','.join(initpylist)}
 
     extra = ['--worker-port 10002:10100']
@@ -61,7 +63,7 @@ def main():
     parser.add_option('-N', '--nFiles',    help='nFiles',            dest='nFiles',    type=int, default=-1)
     parser.add_option('-M', '--startFile', help='startFile',         dest='startFile', type=int, default=0)
     parser.add_option(      '--condor',    help='running on condor', dest='condor',              default=False, action='store_true')
-    parser.add_option(      '--dask',      help='running on condor w/ dask', dest='dask',              default=False, action='store_true')
+    parser.add_option(      '--dask',      help='run w/ dask', dest='dask',              default=False, action='store_true')
     parser.add_option(      '--port',      help='port for dask status dashboard (localhost:port)', dest='port', type=int, default=8787)
     parser.add_option(      '--mincores',  help='dask waits for min # cores', dest='mincores', type=int, default=4)
     parser.add_option(      '--quiet',     help='suppress status printouts', dest='quiet',              default=False, action='store_true')

--- a/analyze.py
+++ b/analyze.py
@@ -105,6 +105,7 @@ def main():
     # export the histograms to root files
     ## the loop makes sure we are only saving the histograms that are filled
     fout = uproot.recreate(outfile)
+    if isinstance(output,tuple): output = output[0]
     for key,H in output.items():
         if type(H) is hist.Hist and H._sumw2 is not None:
             fout[key] = hist.export1d(H)

--- a/analyze.py
+++ b/analyze.py
@@ -8,11 +8,10 @@ import time
 from optparse import OptionParser
 from glob import glob
 
-def use_dask(njobs):
+def use_dask(njobs,port):
     from dask.distributed import Client
     from lpc_dask.lpc_dask import HTCondorCluster
     import socket
-    import time
 
     # make list of local package directories (absolute paths) that should be sent to jobs
     initpylist = [os.path.abspath(os.path.dirname(x)) for x in glob('*/__init__.py')]
@@ -31,11 +30,14 @@ def use_dask(njobs):
         nanny=False,
         extra=extra,
         job_extra=job_extra,
+        diagnostics_port=port,
     )
 
     cluster.scale(jobs=njobs)
 
-    client = Client(cluster)
+    client = Client(cluster,
+        timeout=100
+    )
 
     exe_args = {
         'client': client,
@@ -58,6 +60,7 @@ def main():
     parser.add_option('-M', '--startFile', help='startFile',         dest='startFile', type=int, default=0)
     parser.add_option(      '--condor',    help='running on condor', dest='condor',              default=False, action='store_true')
     parser.add_option(      '--dask',      help='running on condor w/ dask', dest='dask',              default=False, action='store_true')
+    parser.add_option(      '--port',      help='port for dask status dashboard (localhost:port)', dest='port', type=int, default=8787)
     parser.add_option(      '--quiet',     help='suppress status printouts', dest='quiet',              default=False, action='store_true')
     parser.add_option('-w', '--workers',   help='Number of workers to use for multi-worker executors (e.g. futures or condor)', dest='workers', type=int, default=8)
     parser.add_option('-s', '--chunksize', help='Chunk size',        dest='chunksize', type=int, default=10000)
@@ -74,8 +77,14 @@ def main():
     # get processor args
     exe_args = {'workers': options.workers, 'flatten': False}
     if options.dask:
-        exe_args = use_dask(options.workers)
+        exe_args = use_dask(options.workers,options.port)
         if options.quiet: exe_args['status'] = False
+
+        client = exe_args['client']
+        while len(client.ncores()) < 4:
+            print('Waiting for more cores to spin up, currently there are {0} available...'.format(len(client.ncores())))
+            print('Dask client info ->', client)
+            time.sleep(10)
 
     # run processor
     output = processor.run_uproot_job(

--- a/analyze.py
+++ b/analyze.py
@@ -2,10 +2,50 @@
 from coffea import hist, processor
 from processors.mainProcessor import MainProcessor
 import uproot
-import sys
+import sys,os
 from utils import samples as s
 import time
 from optparse import OptionParser
+from glob import glob
+
+def use_dask(njobs):
+    from dask.distributed import Client
+    from lpc_dask.lpc_dask import HTCondorCluster
+    import socket
+    import time
+
+    # make list of local package directories (absolute paths) that should be sent to jobs
+    initpylist = [os.path.abspath(os.path.dirname(x)) for x in glob('*/__init__.py')]
+    job_extra = {'transfer_input_files': ','.join(initpylist)}
+
+    extra = ['--worker-port 10002:10100']
+
+    hostname = socket.gethostname()
+
+    cluster = HTCondorCluster(
+        scheduler_options = {'host': f'{hostname}:10000'},
+        cores=1,
+        memory="2GB",
+        disk="2GB",
+        python='python',
+        nanny=False,
+        extra=extra,
+        job_extra=job_extra,
+    )
+
+    cluster.scale(jobs=njobs)
+
+    client = Client(cluster)
+
+    exe_args = {
+        'client': client,
+        'savemetrics': True,
+        'schema': None,
+        'nano': False,
+        'align_clusters': True
+    }
+
+    return exe_args
 
 def main():
     # start run time clock
@@ -17,24 +57,35 @@ def main():
     parser.add_option('-N', '--nFiles',    help='nFiles',            dest='nFiles',    type=int, default=-1)
     parser.add_option('-M', '--startFile', help='startFile',         dest='startFile', type=int, default=0)
     parser.add_option(      '--condor',    help='running on condor', dest='condor',              default=False, action='store_true')
+    parser.add_option(      '--dask',      help='running on condor w/ dask', dest='dask',              default=False, action='store_true')
+    parser.add_option(      '--quiet',     help='suppress status printouts', dest='quiet',              default=False, action='store_true')
     parser.add_option('-w', '--workers',   help='Number of workers to use for multi-worker executors (e.g. futures or condor)', dest='workers', type=int, default=8)
     parser.add_option('-s', '--chunksize', help='Chunk size',        dest='chunksize', type=int, default=10000)
+    parser.add_option('-m', '--maxchunks', help='Max number of chunks (for testing)',        dest='maxchunks', type=int, default=None)
     options, args = parser.parse_args()
 
     # set output root file
     sample = options.dataset
-    outfile = "MyAnalysis_%s_%d.root" % (sample, options.startFile) if options.condor else "test.root"
+    outfile = "MyAnalysis_%s_%d.root" % (sample, options.startFile) if options.condor or options.dask else "test.root"
 
     # getting dictionary of files from a sample collection e.g. "2016_QCD, 2016_WJets, 2016_TTJets, 2016_ZJets"
     fileset = s.getFileset(sample, True, options.startFile, options.nFiles)
+
+    # get processor args
+    exe_args = {'workers': options.workers, 'flatten': False}
+    if options.dask:
+        exe_args = use_dask(options.workers)
+        if options.quiet: exe_args['status'] = False
+
     # run processor
     output = processor.run_uproot_job(
         fileset,
         treename='TreeMaker2/PreSelection',
         processor_instance=MainProcessor(),
-        executor=processor.futures_executor,
-        executor_args={'workers': options.workers, 'flatten': False},
+        executor=processor.dask_executor if options.dask else processor.futures_executor,
+        executor_args=exe_args,
         chunksize=options.chunksize,
+        maxchunks=options.maxchunks,
     )
 
     # export the histograms to root files

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/patch.sh
+++ b/patch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+VENV=$1
+
+sed -i 's/ if issubclass(schema, schemas.BaseSchema):/ if schema is not None and issubclass(schema, schemas.BaseSchema):/' ${VENV}/lib/python3.6/site-packages/coffea/processor/executor.py
+
+sed -i 's/"xrootd_handler": uproot4.source.xrootd.XRootDSource/"xrootd_handler": uproot4.source.xrootd.MultithreadedXRootDSource/' ${VENV}/lib/python3.6/site-packages/uproot4/reading.py

--- a/setup.sh
+++ b/setup.sh
@@ -56,7 +56,7 @@ export PYTHONPATH=""
 ln -sf ${lcgprefix}/pyxrootd ${NAME}/${pypackages}/pyxrootd
 ln -sf ${lcgprefix}/XRootD ${NAME}/${pypackages}/XRootD
 git clone git@github.com:cms-svj/lpc_dask
-python -m pip install --no-cache-dir dask[dataframe] distributed dask-jobqueue
+python -m pip install --no-cache-dir dask[dataframe]==2020.12.0 distributed==2020.12.0 dask-jobqueue
 
 $ECHO "\nInstalling 'pip' packages ... "
 python -m pip install --no-cache-dir setuptools pip wheel --upgrade
@@ -73,6 +73,9 @@ else
 	$ECHO "Installing the 'production' version of Coffea ... "
 	python -m pip install --no-cache-dir coffea[dask,spark,parsl]==0.6.47
 fi
+
+# apply patches
+./patch.sh $NAME
 
 # Clone TreeMaker for its lists of samples and files
 $ECHO "\nCloning the TreeMaker repository ..."

--- a/setup.sh
+++ b/setup.sh
@@ -71,7 +71,7 @@ if [[ "$DEV" == "1" ]]; then
 	cd ..
 else
 	$ECHO "Installing the 'production' version of Coffea ... "
-	python -m pip install --no-cache-dir coffea[dask,spark,parsl]
+	python -m pip install --no-cache-dir coffea[dask,spark,parsl]==0.6.47
 fi
 
 # Clone TreeMaker for its lists of samples and files

--- a/setup.sh
+++ b/setup.sh
@@ -44,11 +44,22 @@ source $LCG/setup.sh
 
 # Install most of the needed software in a virtual environment
 # following https://aarongorka.com/blog/portable-virtualenv/, an alternative is https://github.com/pantsbuild/pex
-$ECHO "\nMaking and activiating the virtual environment ... "
+$ECHO "\nMaking and activating the virtual environment ... "
 python -m venv --copies $NAME
 source $NAME/bin/activate
+
+$ECHO "\nSetup for Dask on LPC ... "
+pypackages=lib/python3.6/site-packages/
+lcgprefix=${LCG}/${pypackages}
+# need to remove python path from LCG to avoid dask conflicts
+export PYTHONPATH=""
+ln -sf ${lcgprefix}/pyxrootd ${NAME}/${pypackages}/pyxrootd
+ln -sf ${lcgprefix}/XRootD ${NAME}/${pypackages}/XRootD
+git clone git@github.com:cms-svj/lpc_dask
+python -m pip install --no-cache-dir dask[dataframe] distributed dask-jobqueue
+
 $ECHO "\nInstalling 'pip' packages ... "
-python -m pip install --no-cache-dir setuptools pip --upgrade
+python -m pip install --no-cache-dir setuptools pip wheel --upgrade
 python -m pip install --no-cache-dir xxhash
 python -m pip install --no-cache-dir uproot4
 if [[ "$DEV" == "1" ]]; then
@@ -65,14 +76,14 @@ fi
 
 # Clone TreeMaker for its lists of samples and files
 $ECHO "\nCloning the TreeMaker repository ..."
-git clone git@github.com:TreeMaker/TreeMaker.git ${NAME}/lib/python3.6/site-packages/TreeMaker/
+git clone git@github.com:TreeMaker/TreeMaker.git ${NAME}/${pypackages}/TreeMaker/
 
 # Setup the activation script for the virtual environment
 $ECHO "\nSetting up the activation script for the virtual environment ... "
 sed -i '40s/.*/VIRTUAL_ENV="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}" )")" \&\& pwd)"/' $NAME/bin/activate
 find coffeaenv/bin/ -type f -print0 | xargs -0 -P 4 sed -i '1s/#!.*python$/#!\/usr\/bin\/env python/'
-sed -i "2a source ${LCG}/setup.sh" $NAME/bin/activate
-sed -i "4a source ${LCG}/setup.csh" $NAME/bin/activate.csh
+sed -i "2a source ${LCG}/setup.sh"'\nexport PYTHONPATH=""' $NAME/bin/activate
+sed -i "4a source ${LCG}/setup.csh"'\nsetenv PYTHONPATH ""' $NAME/bin/activate.csh
 
 $ECHO "\nSetting up the ipython/jupyter kernel ... "
 storage_dir=$(readlink -f $PWD)


### PR DESCRIPTION
Dask can be used locally or to submit Condor jobs.

The setup script is updated to pin to specific versions of Coffea and Dask. It also adds http://github.com/cms-svj/lpc_dask, which is required to use Dask. Some small patches are included (these have been submitted upstream to Coffea and will appear in future versions).

To test this, I used a command like:
```
python analyze.py --dask --condor -d 2018_QCD -N 10 -M 0 -w 10 -s 1000 -m 100 --mincores 1
```